### PR TITLE
Add fallback to vanished metadata (Resolves #51)

### DIFF
--- a/addons/vanish/README.md
+++ b/addons/vanish/README.md
@@ -1,7 +1,0 @@
-# squaremap-vanish
-
-squaremap integration for various vanish plugins.
-
-Supported vanish plugins:
- - SuperVanish
- - PremiumVanish

--- a/addons/vanish/src/main/java/xyz/jpenilla/squaremap/addon/vanish/SquaremapVanish.java
+++ b/addons/vanish/src/main/java/xyz/jpenilla/squaremap/addon/vanish/SquaremapVanish.java
@@ -1,24 +1,42 @@
 package xyz.jpenilla.squaremap.addon.vanish;
 
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 import xyz.jpenilla.squaremap.api.Squaremap;
 import xyz.jpenilla.squaremap.api.SquaremapProvider;
 
 public final class SquaremapVanish extends JavaPlugin implements Listener {
+    private Squaremap squaremap;
+
+    private VanishAdapter vanishAdapter = null;
+
     @Override
     public void onEnable() {
-        final Squaremap squaremap = SquaremapProvider.get();
+        this.squaremap = SquaremapProvider.get();
 
         final boolean superVanish = this.getServer().getPluginManager().isPluginEnabled("SuperVanish") ||
             this.getServer().getPluginManager().isPluginEnabled("PremiumVanish");
         if (superVanish) {
-            this.getServer().getPluginManager().registerEvents(new SuperVanish(squaremap), this);
+            this.vanishAdapter = new SuperVanish(this.squaremap);
         }
 
-        if (!superVanish) {
-            this.getLogger().warning("You have installed squaremap-vanish without any supported vanish plugins.");
-            this.getLogger().warning("Supported vanish plugins include: SuperVanish, PremiumVanish");
+        if (this.vanishAdapter == null) {
+            this.getLogger().info("You have installed squaremap-vanish without any explicitly supported vanish plugins (SuperVanish, PremiumVanish). Trying to get vanish status from 'vanished' player metadata value used by some vanish plugins.");
+            this.vanishAdapter = new VanishFallback(this, squaremap);
+        }
+
+        this.getServer().getPluginManager().registerEvents(vanishAdapter, this);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void join(final PlayerJoinEvent event) {
+        final Player player = event.getPlayer();
+        if (this.vanishAdapter.isVanished(player)) {
+            this.squaremap.playerManager().hide(player.getUniqueId());
         }
     }
 }

--- a/addons/vanish/src/main/java/xyz/jpenilla/squaremap/addon/vanish/SquaremapVanish.java
+++ b/addons/vanish/src/main/java/xyz/jpenilla/squaremap/addon/vanish/SquaremapVanish.java
@@ -29,6 +29,7 @@ public final class SquaremapVanish extends JavaPlugin implements Listener {
             this.vanishAdapter = new VanishFallback(this, squaremap);
         }
 
+        this.getServer().getPluginManager().registerEvents(this, this);
         this.getServer().getPluginManager().registerEvents(vanishAdapter, this);
     }
 

--- a/addons/vanish/src/main/java/xyz/jpenilla/squaremap/addon/vanish/SuperVanish.java
+++ b/addons/vanish/src/main/java/xyz/jpenilla/squaremap/addon/vanish/SuperVanish.java
@@ -7,10 +7,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerJoinEvent;
 import xyz.jpenilla.squaremap.api.Squaremap;
 
-public record SuperVanish(Squaremap squaremap) implements Listener {
+public record SuperVanish(Squaremap squaremap) implements VanishAdapter {
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void hide(final PlayerHideEvent event) {
         this.squaremap.playerManager().hide(event.getPlayer().getUniqueId());
@@ -21,11 +20,8 @@ public record SuperVanish(Squaremap squaremap) implements Listener {
         this.squaremap.playerManager().show(event.getPlayer().getUniqueId());
     }
 
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    public void join(final PlayerJoinEvent event) {
-        final Player player = event.getPlayer();
-        if (VanishAPI.isInvisible(player)) {
-            this.squaremap.playerManager().hide(player.getUniqueId());
-        }
+    @Override
+    public boolean isVanished(final Player player) {
+        return VanishAPI.isInvisible(player);
     }
 }

--- a/addons/vanish/src/main/java/xyz/jpenilla/squaremap/addon/vanish/VanishAdapter.java
+++ b/addons/vanish/src/main/java/xyz/jpenilla/squaremap/addon/vanish/VanishAdapter.java
@@ -1,0 +1,9 @@
+package xyz.jpenilla.squaremap.addon.vanish;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.Listener;
+
+public interface VanishAdapter extends Listener {
+
+    boolean isVanished(final Player player);
+}

--- a/addons/vanish/src/main/java/xyz/jpenilla/squaremap/addon/vanish/VanishFallback.java
+++ b/addons/vanish/src/main/java/xyz/jpenilla/squaremap/addon/vanish/VanishFallback.java
@@ -1,0 +1,34 @@
+package xyz.jpenilla.squaremap.addon.vanish;
+
+import org.bukkit.entity.Player;
+import org.bukkit.metadata.MetadataValue;
+import xyz.jpenilla.squaremap.api.Squaremap;
+
+import java.util.List;
+import java.util.UUID;
+
+public class VanishFallback implements VanishAdapter {
+
+    public VanishFallback(final SquaremapVanish plugin, final Squaremap squaremap) {
+        plugin.getServer().getScheduler().runTaskTimer(plugin, () -> {
+            for (final Player player : plugin.getServer().getOnlinePlayers()) {
+                final boolean isVanished = isVanished(player);
+                final UUID playerId = player.getUniqueId();
+                if (isVanished != squaremap.playerManager().hidden(playerId)) {
+                    squaremap.playerManager().hidden(playerId, isVanished);
+                }
+            }
+        }, 0, 20);
+    }
+
+    @Override
+    public boolean isVanished(final Player player) {
+        final List<MetadataValue> list = player.getMetadata("vanished");
+        for (MetadataValue value : list) {
+            if (value.asBoolean()) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
This adds a fallback vanish-status-adapter which uses the `vanished` metadata value (used by several plugins like VanishNoPacket and Essentials too) to get whether or not a player should be hidden.  Due to there not being any event when a metadata value is changed we need to check that in a repeating task. (Which will only run if no compatible plugin is detected though)