### PR TITLE
signs: permit user-selectable custom icons

### DIFF
--- a/addons/signs/README.md
+++ b/addons/signs/README.md
@@ -1,0 +1,47 @@
+# signs
+
+Add map markers using in-game signs.
+
+## permissions required
+
+* `squaremap.signs.admin`
+
+## add a marker
+
+1. In your game client, place a sign block in your world.
+
+2. Set its text to your liking.
+
+3. Hold a filled map in your primary hand. You may use any map item; it does not need to correspond to your current location.
+
+4. Right-click the sign.
+
+A new map marker is added immediately. Refresh the squaremap website to see it.
+
+## update a marker
+
+If the marker sign's text changes, the map marker is updated immediately.
+
+## remove a marker
+
+Either
+
+* Destroy the marker sign, removing it from the world; OR
+
+* Hold a filled map in your primary hand, and left-click the sign.
+
+The map marker is removed immediately.
+
+## tips and tricks
+
+* Simple/safe HTML is permitted in signs
+
+* Add your own icon images to the `customicons/` directory. If the first line of text on the front side of the sign matches the `icon.custom.regexp`, the matched portion will be interpreted as an icon filename.
+
+  The default regexp matches text like:
+
+  ```
+  ![cool_icon]
+  ```
+
+  and uses the image file `customicons/cool_icon.png` as the icon.

--- a/addons/signs/src/main/java/xyz/jpenilla/squaremap/addon/signs/SignsPlugin.java
+++ b/addons/signs/src/main/java/xyz/jpenilla/squaremap/addon/signs/SignsPlugin.java
@@ -2,6 +2,7 @@ package xyz.jpenilla.squaremap.addon.signs;
 
 import org.bukkit.plugin.java.JavaPlugin;
 import xyz.jpenilla.squaremap.addon.signs.config.SignsConfig;
+import xyz.jpenilla.squaremap.addon.signs.data.CustomIcons;
 import xyz.jpenilla.squaremap.addon.signs.data.Icons;
 import xyz.jpenilla.squaremap.addon.signs.data.SignManager;
 import xyz.jpenilla.squaremap.addon.signs.hook.LayerProviderManager;
@@ -13,6 +14,7 @@ public final class SignsPlugin extends JavaPlugin {
     private LayerProviderManager layerProviderManager;
     private SignManager signManager;
     private SignsConfig config;
+    private CustomIcons customIcons;
 
     public SignsPlugin() {
         instance = this;
@@ -24,6 +26,7 @@ public final class SignsPlugin extends JavaPlugin {
         this.config.reload();
 
         Icons.register(this);
+        this.customIcons = CustomIcons.register(this);
 
         this.layerProviderManager = new LayerProviderManager(this);
         this.signManager = new SignManager(this);
@@ -41,6 +44,7 @@ public final class SignsPlugin extends JavaPlugin {
         }
         this.signManager = null;
 
+        this.customIcons.unregister();
         Icons.unregister();
     }
 
@@ -58,5 +62,9 @@ public final class SignsPlugin extends JavaPlugin {
 
     public SignsConfig config() {
         return this.config;
+    }
+
+    public CustomIcons customIcons() {
+        return this.customIcons;
     }
 }

--- a/addons/signs/src/main/java/xyz/jpenilla/squaremap/addon/signs/config/SignsWorldConfig.java
+++ b/addons/signs/src/main/java/xyz/jpenilla/squaremap/addon/signs/config/SignsWorldConfig.java
@@ -41,9 +41,13 @@ public final class SignsWorldConfig extends WorldConfig {
     }
 
     public int iconSize = 16;
+    public boolean iconCustom = false;
+    public String iconCustomRegexp = "^!\\[([^\\]]+)\\]$";
 
     private void iconSettings() {
         this.iconSize = getInt("icon.size", this.iconSize);
+        this.iconCustom = this.getBoolean("icon.custom.enabled", this.iconCustom);
+        this.iconCustomRegexp = this.getString("icon.custom.regexp", this.iconCustomRegexp);
     }
 
     private SignsWorldConfig(Config<?, ?> parent, String world) {

--- a/addons/signs/src/main/java/xyz/jpenilla/squaremap/addon/signs/data/CustomIcons.java
+++ b/addons/signs/src/main/java/xyz/jpenilla/squaremap/addon/signs/data/CustomIcons.java
@@ -1,0 +1,84 @@
+package xyz.jpenilla.squaremap.addon.signs.data;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import javax.imageio.ImageIO;
+
+import org.bukkit.plugin.java.JavaPlugin;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import xyz.jpenilla.squaremap.api.Key;
+import xyz.jpenilla.squaremap.api.SquaremapProvider;
+
+public final class CustomIcons {
+    private static final String KEY_PREFIX = "signs_custom_";
+    private static final String CUSTOM_ICONS_DIR = "customicons";
+
+    private List<Key> keys = new ArrayList<>();
+
+    public static CustomIcons register(final @NonNull JavaPlugin plugin) {
+        CustomIcons out = new CustomIcons();
+
+        final File iconDir = new File(plugin.getDataFolder(), CUSTOM_ICONS_DIR);
+        iconDir.mkdir();
+
+        final File[] iconFiles = iconDir.listFiles();
+        if (iconFiles == null) {
+            plugin.getSLF4JLogger().warn("unable to read customicons directory at \"{}\"", iconDir.getAbsolutePath());
+            return out;
+        }
+
+        for (final File file : iconFiles) {
+            if (!file.isFile()) {
+                continue;
+            }
+            try {
+                final String stem = file.getName().replaceAll("\\..*$", "");
+                final BufferedImage image = ImageIO.read(file);
+                if (image == null) {
+                    throw new IOException("no image data");
+                }
+                final Key key = CustomIcons.asKey(stem);
+                out.keys.add(key);
+                SquaremapProvider.get().iconRegistry().register(key, image);
+                plugin.getSLF4JLogger().trace("loaded custom icon {} → \"{}\"", key, file);
+            } catch (final IOException e) {
+                plugin.getSLF4JLogger().warn("unable to read custom icon \"{}\" as an image", file);
+            }
+        }
+
+        return out;
+    }
+
+    public final Optional<Key> lookup(final @Nullable String iconName) {
+        if (iconName == null || iconName.isEmpty()) {
+            return Optional.empty();
+        }
+        Key k = CustomIcons.asKey(iconName);
+        if (keys.contains(k)) {
+            return Optional.of(k);
+        }
+        return Optional.empty();
+    }
+
+    public void unregister() {
+        for (final Key key : this.keys) {
+            SquaremapProvider.get().iconRegistry().unregister(key);
+        }
+        this.keys.clear();
+    }
+
+    public boolean isEmpty() {
+        return this.keys.isEmpty();
+    }
+
+    private static final Key asKey(final @NonNull String iconName) {
+        return Key.of(KEY_PREFIX + iconName);
+    }
+}

--- a/addons/signs/src/main/java/xyz/jpenilla/squaremap/addon/signs/hook/LayerProviderManager.java
+++ b/addons/signs/src/main/java/xyz/jpenilla/squaremap/addon/signs/hook/LayerProviderManager.java
@@ -43,7 +43,7 @@ public final class LayerProviderManager {
             if (!worldConfig.enabled) {
                 return null;
             }
-            final SignLayerProvider provider = new SignLayerProvider(worldConfig);
+            final SignLayerProvider provider = new SignLayerProvider(worldConfig, this.plugin);
             try {
                 this.plugin.signManager().load(id, provider);
             } catch (final Exception e) {


### PR DESCRIPTION
Add custom icons to the Leaflet map via the signs plugin. Administrators with shell access may add their own image files to the `$dataDir/customicons/` directory, which is now created empty on first run. Image files placed in this directory are registered as custom icons.

When enabled in the configuration, the first line of text on the front of every marker sign is matched against the pattern defined in `icon.custom.regexp`. If the matched text is an icon file, that icon is used in place of the stock "sign" icon.

With the default pattern, a sign with the text content

```txt
![my_cool_icon]
Anything goes
on line three and
line four
```

will attempt to use a custom icon. If the file `$dataDir/customicons/my_cool_icon.png` exists, it will be used as the Leaflet map icon. Otherwise, the stock icon will be used.

This behavior is optional and disabled by default.

Also add a basic README file for this plugin.